### PR TITLE
Implement UnitOfWork pattern in UserRepository

### DIFF
--- a/gateway/internal/domain/repository/unit_of_work.go
+++ b/gateway/internal/domain/repository/unit_of_work.go
@@ -1,0 +1,7 @@
+package repository
+
+import "context"
+
+type UnitOfWork interface {
+	Do(ctx context.Context, fn func(ctx context.Context) error) error
+}

--- a/gateway/internal/infrastructure/repository/postgres/unit_of_work.go
+++ b/gateway/internal/infrastructure/repository/postgres/unit_of_work.go
@@ -1,0 +1,28 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/Barbod-Biometrics/Backend/gateway/internal/domain/repository"
+	"gorm.io/gorm"
+)
+
+type gormUnitOfWork struct {
+	db *gorm.DB
+}
+
+type ctxKey string
+
+const dbTxKey ctxKey = "db_tx"
+
+func NewGormUnitOfWork(db *gorm.DB) repository.UnitOfWork {
+	return &gormUnitOfWork{db: db}
+}
+
+func (u *gormUnitOfWork) Do(ctx context.Context, fn func(ctx context.Context) error) error {
+	return u.db.Transaction(func(tx *gorm.DB) error {
+		txCtx := context.WithValue(ctx, dbTxKey, tx)
+
+		return fn(txCtx)
+	})
+}

--- a/gateway/internal/infrastructure/repository/postgres/user_repository.go
+++ b/gateway/internal/infrastructure/repository/postgres/user_repository.go
@@ -13,22 +13,29 @@ type UserRepository struct {
 	db *gorm.DB
 }
 
+func (r *UserRepository) getDB(ctx context.Context) *gorm.DB {
+	if tx, ok := ctx.Value(dbTxKey).(*gorm.DB); ok {
+		return tx
+	}
+	return r.db
+}
+
 func NewUserRepository(db *gorm.DB) repository.UserRepository {
 	return &UserRepository{db: db}
 }
 
 func (r *UserRepository) CreateUser(ctx context.Context, user *entity.User) error {
-	return r.db.WithContext(ctx).Create(user).Error
+	return r.getDB(ctx).WithContext(ctx).Create(user).Error
 }
 
 func (r *UserRepository) GetByPhoneNumber(ctx context.Context, phoneNumber string) (*entity.User, error) {
 	var user entity.User
-	err := r.db.WithContext(ctx).Where("phone_number = ?", phoneNumber).First(&user).Error
+	err := r.getDB(ctx).WithContext(ctx).Where("phone_number = ?", phoneNumber).First(&user).Error
 	return &user, err
 }
 
 func (r *UserRepository) GetByEmail(ctx context.Context, email string) (*entity.User, error) {
 	var user entity.User
-	err := r.db.WithContext(ctx).Where("email = ?", email).First(&user).Error
+	err := r.getDB(ctx).WithContext(ctx).Where("email = ?", email).First(&user).Error
 	return &user, err
 }


### PR DESCRIPTION
Introduce the UnitOfWork pattern to manage database transactions in the UserRepository, allowing for better transaction handling and improved code organization. The UserRepository now utilizes the UnitOfWork to execute database operations within a transaction context.