### PR TITLE
fix: update User email field to be a pointer and adjust related tests

### DIFF
--- a/gateway/internal/domain/entity/user.go
+++ b/gateway/internal/domain/entity/user.go
@@ -7,7 +7,7 @@ import (
 type User struct {
 	UserID      uint64    `gorm:"primaryKey;autoIncrement" json:"user_id"`
 	PhoneNumber string    `gorm:"type:varchar(15);unique;not null" json:"phone_number"`
-	Email       string    `gorm:"type:varchar(100);unique" json:"email"`
+	Email       *string   `gorm:"type:varchar(100);unique" json:"email,omitempty"`
 	CreatedAt   time.Time `gorm:"not null;default:now()" json:"created_at"`
 }
 

--- a/gateway/internal/infrastructure/repository/postgres/user_repository_test.go
+++ b/gateway/internal/infrastructure/repository/postgres/user_repository_test.go
@@ -46,9 +46,10 @@ func TestUserRepository_CreateAndGet(t *testing.T) {
 	ctx := context.Background()
 
 	phone := "09124206969"
+	email := "info@barbod.com"
 	newUser := &entity.User{
 		PhoneNumber: phone,
-		Email:       "info@barbod.com",
+		Email:       &email,
 	}
 
 	t.Run("Create User", func(t *testing.T) {
@@ -63,17 +64,17 @@ func TestUserRepository_CreateAndGet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get user by phone: %v", err)
 		}
-		if user.PhoneNumber != newUser.PhoneNumber || user.Email != newUser.Email {
+		if user.PhoneNumber != newUser.PhoneNumber || (user.Email == nil || *user.Email != *newUser.Email) {
 			t.Fatalf("retrieved user by phone does not match created user")
 		}
 	})
 
 	t.Run("Get User By Email", func(t *testing.T) {
-		user, err := repo.GetByEmail(ctx, newUser.Email)
+		user, err := repo.GetByEmail(ctx, *newUser.Email)
 		if err != nil {
 			t.Fatalf("failed to get user by email: %v", err)
 		}
-		if user.PhoneNumber != newUser.PhoneNumber || user.Email != newUser.Email {
+		if user.PhoneNumber != newUser.PhoneNumber || (user.Email == nil || *user.Email != *newUser.Email) {
 			t.Fatalf("retrieved user by email does not match created user")
 		}
 	})


### PR DESCRIPTION
This hotfix fixes the issue of not being able to create multiple users. This was due to the email field being defaulted to an empty string of "". 