### PR TITLE
Feat/jwt-middleware

### DIFF
--- a/gateway/cmd/app/main.go
+++ b/gateway/cmd/app/main.go
@@ -15,10 +15,10 @@ import (
 	Logger "github.com/Barbod-Biometrics/Backend/gateway/internal/infrastructure/logger"
 	"github.com/Barbod-Biometrics/Backend/gateway/internal/infrastructure/repository/postgres"
 	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/profile"
-	"github.com/Barbod-Biometrics/Backend/gateway/pkg/database"
-	"github.com/Barbod-Biometrics/Backend/gateway/pkg/storage"
 	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/user"
 	v1 "github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/routes/http/v1"
+	"github.com/Barbod-Biometrics/Backend/gateway/pkg/database"
+	"github.com/Barbod-Biometrics/Backend/gateway/pkg/storage"
 	"github.com/gin-gonic/gin"
 )
 
@@ -100,7 +100,7 @@ func main() {
 
 	// 8. Setup Router
 	// Initialize the V1 Router
-	v1Router := v1.NewRouter(authController, profileHandler)
+	v1Router := v1.NewRouter(authController, profileHandler, jwtKeyManager)
 
 	// Get the handler (which is a Gin Engine)
 	handler := v1Router.RegisterRoutes()

--- a/gateway/cmd/app/main.go
+++ b/gateway/cmd/app/main.go
@@ -27,6 +27,10 @@ import (
 // @description This is the Gateway service API documentation for Barbod Biometrics.
 // @host localhost:8080
 // @BasePath /api/v1
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+// @description Type "Bearer {your JWT token}" to authorize requests (without quotes)
 func main() {
 
 	gin.DisableConsoleColor()

--- a/gateway/internal/presentation/controller/v1/profile/profile_handler.go
+++ b/gateway/internal/presentation/controller/v1/profile/profile_handler.go
@@ -23,7 +23,11 @@ func NewProfileHandler(u usecase.ProfileUsecase) *ProfileHandler {
 // getUserID extracts the authenticated user's ID from the request context.
 // The user ID is set by the JWT middleware after validating the access token.
 func (h *ProfileHandler) getUserID(c *gin.Context) uint64 {
-	return middleware.GetUserIDFromContext(c)
+	userID, err := middleware.GetUserIDFromContext(c)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	}
+	return userID
 }
 
 // CreateDraft creates a new profile draft

--- a/gateway/internal/presentation/controller/v1/profile/profile_handler.go
+++ b/gateway/internal/presentation/controller/v1/profile/profile_handler.go
@@ -28,6 +28,7 @@ func (h *ProfileHandler) getUserID(c *gin.Context) uint64 {
 
 // CreateDraft creates a new profile draft
 // @Summary Create Profile Draft
+// @Security BearerAuth
 // @Description Create a new profile draft
 // @Tags Profiles
 // @Accept json
@@ -55,6 +56,7 @@ func (h *ProfileHandler) CreateDraft(c *gin.Context) {
 
 // UpdateDraft updates fields of an existing profile draft
 // @Summary Update Profile Draft
+// @Security BearerAuth
 // @Description Update a profile draft (partial updates allowed)
 // @Tags Profiles
 // @Accept json
@@ -92,6 +94,7 @@ func (h *ProfileHandler) UpdateDraft(c *gin.Context) {
 
 // SaveDocument handles POST /api/v1/profiles/:id/documents
 // @Summary Save Document URL
+// @Security BearerAuth
 // @Description Save a document URL for a profile (e.g., national card, business docs)
 // @Tags Profiles
 // @Accept json
@@ -129,6 +132,7 @@ func (h *ProfileHandler) SaveDocument(c *gin.Context) {
 
 // Submit handles POST /api/v1/profiles/:id/submit
 // @Summary Submit Profile
+// @Security BearerAuth
 // @Description Submit a profile for verification (final submission)
 // @Tags Profiles
 // @Accept json
@@ -159,6 +163,7 @@ func (h *ProfileHandler) Submit(c *gin.Context) {
 
 // GetProfile handles GET /api/v1/profiles/:id
 // @Summary Get Profile
+// @Security BearerAuth
 // @Description Get a profile by id
 // @Tags Profiles
 // @Accept json
@@ -189,6 +194,7 @@ func (h *ProfileHandler) GetProfile(c *gin.Context) {
 
 // GetUploadUrl handles POST /api/v1/profiles/upload-url
 // @Summary Get Upload URL
+// @Security BearerAuth
 // @Description Get a pre-signed upload URL for document uploads
 // @Tags Profiles
 // @Accept json

--- a/gateway/internal/presentation/controller/v1/profile/profile_handler.go
+++ b/gateway/internal/presentation/controller/v1/profile/profile_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Barbod-Biometrics/Backend/gateway/internal/application/dto/profile"
 	"github.com/Barbod-Biometrics/Backend/gateway/internal/application/usecase"
+	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/middleware"
 	"github.com/gin-gonic/gin"
 )
 
@@ -19,12 +20,10 @@ func NewProfileHandler(u usecase.ProfileUsecase) *ProfileHandler {
 	}
 }
 
-// --- Helper to get UserID ---
-// TODO: Replace this with actual JWT middleware logic later
+// getUserID extracts the authenticated user's ID from the request context.
+// The user ID is set by the JWT middleware after validating the access token.
 func (h *ProfileHandler) getUserID(c *gin.Context) uint64 {
-	// For testing now, return a static ID (e.g., 1)
-	// Later, this will be: c.GetUint64("userID")
-	return 1
+	return middleware.GetUserIDFromContext(c)
 }
 
 // CreateDraft creates a new profile draft

--- a/gateway/internal/presentation/middleware/jwt.go
+++ b/gateway/internal/presentation/middleware/jwt.go
@@ -33,15 +33,12 @@ func JWTMiddleware(keyManager domainJWT.KeyManager) gin.HandlerFunc {
 
 		// Parse and validate the token
 		token, err := jwt.Parse(tokenString, func(tok *jwt.Token) (interface{}, error) {
-			// Ensure signing method is RSA
-			if _, ok := tok.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", tok.Header["alg"])
-			}
+
 			return keyManager.GetPublicKey(), nil
 		}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
 
 		if err != nil || !token.Valid {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("invalid token: %v", err)})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
 			return
 		}
 
@@ -82,15 +79,15 @@ func extractUserID(sub interface{}) (uint64, error) {
 	}
 }
 
-// GetUserIDFromContext extracts user ID from gin context
-// Returns 0 if user ID is not found or invalid
-func GetUserIDFromContext(c *gin.Context) uint64 {
+// GetUserIDFromContext extracts user ID from gin context.
+// Returns the user ID and an error if not found or invalid.
+func GetUserIDFromContext(c *gin.Context) (uint64, error) {
 	v, exists := c.Get(ContextKeyUserID)
 	if !exists {
-		return 0
+		return 0, fmt.Errorf("user ID not found in context")
 	}
 	if uid, ok := v.(uint64); ok {
-		return uid
+		return uid, nil
 	}
-	return 0
+	return 0, fmt.Errorf("user ID in context has invalid type: %T", v)
 }

--- a/gateway/internal/presentation/middleware/jwt.go
+++ b/gateway/internal/presentation/middleware/jwt.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	domainJWT "github.com/Barbod-Biometrics/Backend/gateway/internal/domain/jwt"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ContextKeyUserID is the key used to store user ID in gin context
+const ContextKeyUserID = "userID"
+
+// JWTMiddleware creates a middleware that validates JWT tokens and extracts user ID
+func JWTMiddleware(keyManager domainJWT.KeyManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing authorization header"})
+			return
+		}
+
+		parts := strings.Fields(authHeader)
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header format"})
+			return
+		}
+
+		tokenString := parts[1]
+
+		// Parse and validate the token
+		token, err := jwt.Parse(tokenString, func(tok *jwt.Token) (interface{}, error) {
+			// Ensure signing method is RSA
+			if _, ok := tok.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", tok.Header["alg"])
+			}
+			return keyManager.GetPublicKey(), nil
+		}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
+
+		if err != nil || !token.Valid {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("invalid token: %v", err)})
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token claims"})
+			return
+		}
+
+		// Extract user ID from "sub" claim
+		userID, err := extractUserID(claims["sub"])
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid user id in token"})
+			return
+		}
+
+		// Set user ID in context for handlers to use
+		c.Set(ContextKeyUserID, userID)
+		c.Next()
+	}
+}
+
+// extractUserID extracts user ID from the sub claim which can be float64, string, or int
+func extractUserID(sub interface{}) (uint64, error) {
+	switch v := sub.(type) {
+	case float64:
+		return uint64(v), nil
+	case string:
+		return strconv.ParseUint(v, 10, 64)
+	case int:
+		return uint64(v), nil
+	case int64:
+		return uint64(v), nil
+	case uint64:
+		return v, nil
+	default:
+		return 0, fmt.Errorf("unexpected sub claim type: %T", sub)
+	}
+}
+
+// GetUserIDFromContext extracts user ID from gin context
+// Returns 0 if user ID is not found or invalid
+func GetUserIDFromContext(c *gin.Context) uint64 {
+	v, exists := c.Get(ContextKeyUserID)
+	if !exists {
+		return 0
+	}
+	if uid, ok := v.(uint64); ok {
+		return uid
+	}
+	return 0
+}

--- a/gateway/internal/presentation/routes/http/v1/routes.go
+++ b/gateway/internal/presentation/routes/http/v1/routes.go
@@ -4,26 +4,31 @@ import (
 	"net/http"
 
 	_ "github.com/Barbod-Biometrics/Backend/gateway/docs"
+	domainJWT "github.com/Barbod-Biometrics/Backend/gateway/internal/domain/jwt"
+	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/profile"
+	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/user"
+	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/middleware"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 
-	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/profile"
-	"github.com/Barbod-Biometrics/Backend/gateway/internal/presentation/controller/v1/user"
 	"github.com/gin-gonic/gin"
 )
 
 type Route struct {
 	authController    *user.GeneralUserController
 	profileController *profile.ProfileHandler
+	jwtKeyManager     domainJWT.KeyManager
 }
 
 func NewRouter(
 	authController *user.GeneralUserController,
 	profileHandler *profile.ProfileHandler,
+	jwtKeyManager domainJWT.KeyManager,
 ) *Route {
 	return &Route{
 		authController:    authController,
 		profileController: profileHandler,
+		jwtKeyManager:     jwtKeyManager,
 	}
 }
 
@@ -43,6 +48,7 @@ func (r *Route) RegisterRoutes() http.Handler {
 			auth.POST("/verify-otp", r.authController.VerifyOTPHandler)
 		}
 		profiles := v1.Group("/profiles")
+		profiles.Use(middleware.JWTMiddleware(r.jwtKeyManager))
 		{
 			profiles.POST("/", r.profileController.CreateDraft)
 			profiles.PATCH("/:id", r.profileController.UpdateDraft)


### PR DESCRIPTION
This PR adds a JWT middleware in which it enables the profile creation APIs to find out which user ID is calling the API and it would extract the userID of the user calling the API from the bearer authorization header provided.

Also, this adds the ability of providing the bearer token when testing the APIs via swagger.