### PR TITLE
fix: correct formatting string in generateOTP function

### DIFF
--- a/gateway/internal/application/service/otp_service.go
+++ b/gateway/internal/application/service/otp_service.go
@@ -130,6 +130,6 @@ func (s *otpService) generateOTP(length int) (string, error) {
 		return "", err
 	}
 
-	format := fmt.Sprintf("%%0%ddd", length)
+	format := fmt.Sprintf("%%0%dd", length)
 	return fmt.Sprintf(format, n.Int64()), nil
 }


### PR DESCRIPTION
This PR is a hotfix for the OTP code mistakenly having a "d" at the end of it.