### PR TITLE
Fix/multi business national id uniq violation

### DIFF
--- a/gateway/internal/application/service/admin_profile_service.go
+++ b/gateway/internal/application/service/admin_profile_service.go
@@ -166,7 +166,7 @@ func (s *AdminProfileService) GetProfileDetail(ctx context.Context, profileID ui
 			RepNationalID:      p.BusinessDetails.RepNationalID,
 			RepDOB:             &dob,
 			RepMobileNumber:    p.BusinessDetails.RepMobileNumber,
-			BusinessNationalID: p.BusinessDetails.BusinessNationalID,
+			BusinessNationalID: *p.BusinessDetails.BusinessNationalID,
 		}
 		if p.BusinessDetails.BusinessInfo != nil {
 			resp.BusinessDetails.BusinessInfo = &profile.BusinessMetaDTO{

--- a/gateway/internal/application/service/profile_service_impl.go
+++ b/gateway/internal/application/service/profile_service_impl.go
@@ -63,7 +63,7 @@ func (s *ProfileService) UpdateDraft(ctx context.Context, userID uint64, profile
 	}
 
 	if existing.VerificationStatus != entity.StatusDraft && existing.VerificationStatus != entity.StatusRejected {
-		return nil, fmt.Errorf("cannot update a profile that is peding or verified")
+		return nil, fmt.Errorf("cannot update a profile that is pending or verified")
 	}
 
 	if req.ProfileName != nil {

--- a/gateway/internal/application/service/profile_service_impl.go
+++ b/gateway/internal/application/service/profile_service_impl.go
@@ -129,12 +129,14 @@ func (s *ProfileService) mapEntityToResponse(e *entity.Profile) *profile.Profile
 
 	if e.BusinessDetails != nil {
 		resp.BusinessDetails = &profile.BusinessDetailsResponse{
-			RepFirstName:       e.BusinessDetails.RepFirstName,
-			RepLastName:        e.BusinessDetails.RepLastName,
-			RepNationalID:      e.BusinessDetails.RepNationalID,
-			RepDOB:             &e.BusinessDetails.RepDOB,
-			RepMobileNumber:    e.BusinessDetails.RepMobileNumber,
-			BusinessNationalID: e.BusinessDetails.BusinessNationalID,
+			RepFirstName:    e.BusinessDetails.RepFirstName,
+			RepLastName:     e.BusinessDetails.RepLastName,
+			RepNationalID:   e.BusinessDetails.RepNationalID,
+			RepDOB:          &e.BusinessDetails.RepDOB,
+			RepMobileNumber: e.BusinessDetails.RepMobileNumber,
+		}
+		if e.BusinessDetails.BusinessNationalID != nil {
+			resp.BusinessDetails.BusinessNationalID = *e.BusinessDetails.BusinessNationalID
 		}
 
 		resp.BusinessDetails.LocationInfo = s.mapLocationEntityToDTO(e.BusinessDetails.LocationInfo)
@@ -261,7 +263,7 @@ func (s *ProfileService) updateBusinessDetails(target *entity.ProfileBusinessDet
 	}
 
 	if source.BusinessNationalID != nil {
-		target.BusinessNationalID = *source.BusinessNationalID
+		target.BusinessNationalID = source.BusinessNationalID
 	}
 
 	if source.BusinessInfo != nil {

--- a/gateway/internal/domain/entity/profile.go
+++ b/gateway/internal/domain/entity/profile.go
@@ -96,7 +96,7 @@ type ProfileBusinessDetails struct {
 	RepDOB          time.Time `gorm:"type:date;not null" json:"rep_dob"`
 	RepMobileNumber string    `gorm:"type:varchar(15);not null;unique" json:"rep_mobile_number"`
 
-	BusinessNationalID string `gorm:"type:varchar(15);not null;unique" json:"business_national_id"`
+	BusinessNationalID *string `gorm:"type:varchar(15);unique" json:"business_national_id"`
 
 	BusinessInfo      *BusinessMetaData  `gorm:"type:jsonb;serializer:json" json:"business_info"`
 	LocationInfo      *LocationInfo      `gorm:"type:jsonb;serializer:json" json:"location_info"`


### PR DESCRIPTION
This PR fixes the issue of a business national id uniqueness violation when a user created a draft, updated it without providing business national ID and then another user tried to do the same. This was due to the fact that the business national id field used to default to an empty string. Now it defaults to a nil value.

Also, I have fixed a very minor typo.