### PR TITLE
fix: forcing redis to accept write commands

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -20,7 +20,7 @@ services:
       - "6379:${REDIS_PORT}"
     volumes:
       - redis-data:/data
-    command: redis-server --appendonly yes # for data persistance
+    command: redis-server --appendonly yes --replica-read-only no # for data persistance
     healthcheck:  # for container health monitoring
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "6379:${REDIS_PORT}"
     volumes:
       - redis-data:/data
-    command: redis-server --appendonly yes # for data persistance
+    command: redis-server --appendonly yes --replica-read-only no # for data persistance
     healthcheck:  # for container health monitoring
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
This is not a best practive for production, but it is ok for the local development.
the problem was that we were running a single Redis container. Logically, it must be the master, but it ran as a replica and gave us 500 error accessing it.

This is common "Ghost" issue in Docker setups with persistent volumes.

The best practice for this is to use a mounted `redis.conf` and instead of hacking the startup command, we will feed Redis a strict configuration file, this prevents the "Zombie State" because Redis will read this file on every boot. 