### PR TITLE
Fix redundant reference in APIKey struct

### DIFF
--- a/gateway/internal/domain/entity/api_key.go
+++ b/gateway/internal/domain/entity/api_key.go
@@ -5,7 +5,7 @@ import "time"
 type APIKey struct {
 	KeyID     uint64    `gorm:"primaryKey;autoIncrement" json:"key_id"`
 	ProfileID uint64    `gorm:"not null;index" json:"profile_id"`
-	Profile   *Profile  `gorm:"foreignKey:ProfileID;references:ProfileID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"-"`
+	Profile   *Profile  `gorm:"foreignKey:ProfileID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"-"`
 	KeyHash   string    `gorm:"type:varchar(256); not null; unique" json:"key_hash"`
 	KeyPrefix string    `gorm:"type:varchar(8); not null; unique" json:"key_prefix"`
 	IsActive  bool      `gorm:"not null; default:true" json:"is_active"`


### PR DESCRIPTION
Remove unnecessary reference in the APIKey struct to streamline the foreign key constraint for the Profile field.